### PR TITLE
Fix some memory leaks.

### DIFF
--- a/lib/testsuite/testsuite.c
+++ b/lib/testsuite/testsuite.c
@@ -198,7 +198,7 @@ START_TEST (test_ascii)
 	fail_if(errval != MAPIROPS_ERR_SUCCESS);
 	fail_if(strcmp(in, out));
 
-	talloc_free(mem_ctx);
+	COMMON_TEST_END();
 }
 END_TEST
 
@@ -223,7 +223,7 @@ START_TEST (test_ascii_noterm)
 	fail_if(errval != MAPIROPS_ERR_SUCCESS);
 	fail_if(strcmp(in, out));
 
-	talloc_free(mem_ctx);
+	COMMON_TEST_END();
 }
 END_TEST
 
@@ -251,7 +251,7 @@ START_TEST (test_utf16)
 	fail_if(errval != MAPIROPS_ERR_SUCCESS);
 	fail_if(strcmp(in, out));
 
-	talloc_free(mem_ctx);
+	COMMON_TEST_END();
 }
 END_TEST
 
@@ -276,7 +276,7 @@ START_TEST (test_utf16_noterm)
 	fail_if(errval != MAPIROPS_ERR_SUCCESS);
 	fail_if(strcmp(in, out));
 
-	talloc_free(mem_ctx);
+	COMMON_TEST_END();
 }
 END_TEST
 
@@ -309,7 +309,7 @@ START_TEST (test_bytes)
 	fail_if(memcmp(in, out, strlen(BYTE_TEST_STR)));
 	fail_if(memcmp(out, BYTE_TEST_STR, strlen(BYTE_TEST_STR)));
 
-	talloc_free(mem_ctx);
+	COMMON_TEST_END();
 }
 END_TEST
 
@@ -347,7 +347,7 @@ START_TEST (test_GUID)
 		fail_if(in.Data3 != out.Data3);
 		fail_if(memcmp(in.Data4, out.Data4, 8));
 	
-		talloc_free(mem_ctx);
+		COMMON_TEST_END();
 	}
 
 	/* GUID 38 */
@@ -371,7 +371,7 @@ START_TEST (test_GUID)
 		fail_if(in.Data3 != out.Data3);
 		fail_if(memcmp(in.Data4, out.Data4, 8));
 	
-		talloc_free(mem_ctx);
+		COMMON_TEST_END();
 
 	}
 }
@@ -394,6 +394,8 @@ START_TEST (test_MAPISTATUS)
 	fail_if(errval != MAPIROPS_ERR_SUCCESS);
 	fail_if(pull->offset != sizeof(enum MAPISTATUS));
 	fail_if(out != MAPI_E_NO_ACCESS);
+
+        COMMON_TEST_END();
 }
 END_TEST
 
@@ -454,12 +456,15 @@ int main(int argc, const char *argv[])
 		switch (opt) {
 		case OPT_REFS:
 			testsuite_print_references();
+                        poptFreeContext(pc);
 			exit(0);
 			break;
 		default:
 			break;
 		}
 	}
+
+	poptFreeContext(pc);
 
 	s = primitives_suite();
 	sr = srunner_create(s);

--- a/lib/testsuite/testsuite_oxcstor.c
+++ b/lib/testsuite/testsuite_oxcstor.c
@@ -61,6 +61,8 @@ START_TEST (test_RopLogon_LogonFlags)
 	fail_if(!MAPIROPS_ERR_CODE_IS_SUCCESS(errval) || r != (LogonFlags_Ghosted|LogonFlags_UnderCover));
 	fail_if(pull->offset != push->offset);
 
+        COMMON_TEST_END()
+
 }
 END_TEST
 
@@ -115,6 +117,8 @@ START_TEST (test_RopLogon_OpenFlags)
 	fail_if(!MAPIROPS_ERR_CODE_IS_SUCCESS(errval) || r != OpenFlags_USE_PER_MDB_REPLID_MAPPING);
 	errval = mapirops_pull_enum_OpenFlags (pull, &r);
 	fail_if(!MAPIROPS_ERR_CODE_IS_SUCCESS(errval) || r != OpenFlags_SUPPORT_PROGRESS);
+
+        COMMON_TEST_END()
 }
 END_TEST
 
@@ -145,6 +149,7 @@ START_TEST (test_RopLogon_request)
 		errval = mapirops_push_struct_RopLogon_request(push, &request);
 		fail_if(errval != MAPIROPS_ERR_SUCCESS);
 
+                pull->mem_ctx = mem_ctx;
 		pull->data = push->data;
 		
 		errval = mapirops_pull_struct_RopLogon_request(pull, &orequest);
@@ -157,7 +162,7 @@ START_TEST (test_RopLogon_request)
 		fail_if(request.EssDnSize != orequest.EssDnSize);
 		fail_if(strcmp(request.EssDn, orequest.EssDn));
 
-		talloc_free(mem_ctx);
+		COMMON_TEST_END()
 	}
 
 	/* Test with EssDnSize == 0x0 */
@@ -170,6 +175,7 @@ START_TEST (test_RopLogon_request)
 		errval = mapirops_push_struct_RopLogon_request(push, &request);
 		fail_if(errval != MAPIROPS_ERR_SUCCESS);
 
+                pull->mem_ctx = mem_ctx;
 		pull->data = push->data;
 		errval = mapirops_pull_struct_RopLogon_request(pull, &orequest);
 		fail_if(errval != MAPIROPS_ERR_SUCCESS);
@@ -180,7 +186,7 @@ START_TEST (test_RopLogon_request)
 		fail_if(request.StoreState != orequest.StoreState);
 		fail_if(request.EssDnSize != orequest.EssDnSize);
 
-		talloc_free(mem_ctx);
+                COMMON_TEST_END()
 	}
 
 
@@ -194,6 +200,7 @@ START_TEST (test_RopLogon_request)
 		errval = mapirops_push_struct_RopLogon_request(push, &request);
 		fail_if(errval != MAPIROPS_ERR_SUCCESS);
 
+                pull->mem_ctx = mem_ctx;
 		pull->data = push->data;
 		errval = mapirops_pull_struct_RopLogon_request(pull, &orequest);
 		fail_if(errval != MAPIROPS_ERR_SUCCESS);
@@ -204,7 +211,7 @@ START_TEST (test_RopLogon_request)
 		fail_if(request.StoreState != orequest.StoreState);
 		fail_if(request.EssDnSize != orequest.EssDnSize);
 
-		talloc_free(mem_ctx);
+                COMMON_TEST_END()
 	}
 }
 END_TEST
@@ -244,7 +251,8 @@ START_TEST (test_RopLogon_LogonTime)
 		fail_if(LogonTime.Day != oLogonTime.Day);
 		fail_if(LogonTime.CurrentMonth != oLogonTime.CurrentMonth);
 		fail_if(LogonTime.Year != oLogonTime.Year);
-		talloc_free(mem_ctx);
+
+		COMMON_TEST_END()
 	}
 
 	/* Test invalid LogonTime DayOfWeek */
@@ -253,7 +261,7 @@ START_TEST (test_RopLogon_LogonTime)
 		LogonTime.DayOfWeek = 9;
 		errval = mapirops_push_struct_LogonTime(push, &LogonTime);
 		fail_if(errval != MAPIROPS_ERR_INVALID_VAL);
-		talloc_free(mem_ctx);
+		COMMON_TEST_END()
 	}
 
 	/* Test invalid LogonTime Month */
@@ -263,7 +271,7 @@ START_TEST (test_RopLogon_LogonTime)
 		LogonTime.CurrentMonth = 14;
 		errval = mapirops_push_struct_LogonTime(push, &LogonTime);
 		fail_if(errval != MAPIROPS_ERR_INVALID_VAL);
-		talloc_free(mem_ctx);
+		COMMON_TEST_END()
 	}
 
 }
@@ -281,7 +289,8 @@ START_TEST (test_RopLogon_response_OK)
 	/* Mailbox response */
 	{
 		COMMON_TEST_START(RopLogon_response);
-	}
+                COMMON_TEST_END()
+        }
 
 	/* Public folders response */
 }
@@ -303,6 +312,7 @@ Suite *oxcstor_suite(void)
 {
 	Suite	*s;
 	TCase	*TRopLogon;
+        TCase   *TRopGetReceiveFolder;
 
 	s = suite_create("[MS-OXCSTOR] ROPS");
 	TRopLogon = tcase_create("[MS-OXCSTOR] RopLogon");
@@ -316,7 +326,8 @@ Suite *oxcstor_suite(void)
 	tcase_add_test(TRopLogon, test_RopLogon_response_OK);
 	tcase_add_test(TRopLogon, test_RopLogon_response_Failure);
 	tcase_add_test(TRopLogon, test_RopLogon_response_Redirect);
-	return s;
+
+        return s;
 }
 
 void oxcstor_suite_references(void)


### PR DESCRIPTION
Mostly the issue was missing call to talloc_free() in the test code. Swapped to the cleanup macro everywhere.

One issue that was more complex was push / pull zero-length strings, which required some special case handling. That part (lib/mapirops.c) needs review.
